### PR TITLE
fix(rag): Group regex alternatives for explicit precedence

### DIFF
--- a/apps/backend/services/rag/complete_medical_rag.py
+++ b/apps/backend/services/rag/complete_medical_rag.py
@@ -250,8 +250,8 @@ class MedicalDocumentProcessor:
         for line in lines[:3]:  # Check first 3 lines
             line = line.strip()
             if line.startswith('#') or line.isupper() or line.startswith('**'):
-                # Clean section name
-                section = re.sub(r'^#+\s*|\*\*|[^\w\s]', '', line).strip()
+                # Clean section name (remove markdown formatting and special chars)
+                section = re.sub(r'(^#+\s*|\*\*|[^\w\s])', '', line).strip()
                 return section[:50]  # Limit length
         return "content"
 


### PR DESCRIPTION
## Summary
Fix SonarLint warning python:S5850 in RAG service regex pattern

## Changes
- Grouped regex alternatives for explicit operator precedence
- Pattern `^#+\s*|\*\*|[^\w\s]` → `(^#+\s*|\*\*|[^\w\s])`
- Ensures anchor `^` correctly applies only to first alternative
- Improves code reliability and maintainability

## Test plan
- [x] No change in functionality - only explicit grouping added
- [x] Regex still removes markdown headers, asterisks, and special chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)